### PR TITLE
avoid permissions errors

### DIFF
--- a/bin/spitball
+++ b/bin/spitball
@@ -36,7 +36,7 @@ opts = OptionParser.new do |opts|
 
   opts.separator ""
   opts.separator "environment variables:"
-  opts.separator "\tSPITBALL_CACHE\t\t     Specifies the cache dir. Defaults to /tmp/spitball"
+  opts.separator "\tSPITBALL_CACHE\t\t     Specifies the cache dir. Defaults to /tmp/spitball.$USER"
   opts.separator ""
 end
 

--- a/lib/spitball/remote.rb
+++ b/lib/spitball/remote.rb
@@ -11,7 +11,7 @@ class Spitball::Remote
     @host      = opts[:host]
     @port      = opts[:port]
     @without   = (opts[:without] || []).map{|w| w.to_sym}
-    @cache_dir = File.join(ENV['SPITBALL_CACHE'] || '/tmp/spitball', 'client')
+    @cache_dir = File.join(ENV['SPITBALL_CACHE'] || '/tmp/spitball.#{ENV['USER']}', 'client')
     FileUtils.mkdir_p(@cache_dir)
     use_cache_file
   end

--- a/lib/spitball/repo.rb
+++ b/lib/spitball/repo.rb
@@ -1,7 +1,7 @@
 module Spitball::Repo
   extend self
 
-  WORKING_DIR = ENV['SPITBALL_CACHE'] || '/tmp/spitball'
+  WORKING_DIR = ENV['SPITBALL_CACHE'] || '/tmp/spitball.#{ENV['USER']}'
 
   def bundle_path(digest, extension = nil)
     extension = ".#{extension}" unless extension.nil? or extension.empty?

--- a/lib/spitball/version.rb
+++ b/lib/spitball/version.rb
@@ -1,3 +1,3 @@
 class Spitball
-  VERSION = '0.4.5'
+  VERSION = '0.4.6'
 end


### PR DESCRIPTION
spitball now creates a temp directory per user to avoid permission issues on hosts where multiple users run spitball, reving version

//

The environment variable thing works... but this will allow people to not worry about it.
