### PR TITLE
add suport for multi-groups and tests

### DIFF
--- a/lib/ext/bundler_fake_dsl.rb
+++ b/lib/ext/bundler_fake_dsl.rb
@@ -1,6 +1,6 @@
 module Bundler
   class FakeDsl
-    
+
     def initialize(file)
       @groups = Hash.new{|h, k| h[k] = []}
       @gems = []
@@ -19,10 +19,12 @@ module Bundler
       __gems.map(&:first)
     end
 
-    def group(name, &blk)
-      @current_group = name.to_sym
-      instance_eval(&blk)
-      @current_group = nil
+    def group(*group_names, &blk)
+      group_names.each do |name|
+        @current_group = name.to_sym
+        instance_eval(&blk)
+        @current_group = nil
+      end
     end
     alias_method :groups, :group
 
@@ -30,7 +32,7 @@ module Bundler
       @gems << args
       @groups[@current_group] << args.first
     end
-    
+
     def method_missing(*args)
     end
   end

--- a/spec/spitball_spec.rb
+++ b/spec/spitball_spec.rb
@@ -305,3 +305,55 @@ describe Spitball do
     end
   end
 end
+
+describe Bundler::FakeDsl do
+  it "should support a single group" do
+    gemfile = <<-end_gemfile
+        source :rubygems
+        gem "json_pure"
+
+        group :development do
+          gem 'rails'
+          gem 'json_pure'
+        end
+      end_gemfile
+
+    dsl = Bundler::FakeDsl.new(gemfile)
+    dsl.__groups[:development].should == ["rails", "json_pure"]
+  end
+
+  it "should support multiple groups in one line" do
+    gemfile = <<-end_gemfile
+        source :rubygems
+        gem "json_pure"
+
+        group :development, :test do
+          gem 'rails'
+          gem 'json_pure'
+        end
+      end_gemfile
+
+    dsl = Bundler::FakeDsl.new(gemfile)
+    dsl.__groups[:development].should == ["rails", "json_pure"]
+    dsl.__groups[:test].should == ["rails", "json_pure"]
+  end
+
+  it "should support multiple groups on several lines" do
+    gemfile = <<-end_gemfile
+        source :rubygems
+        gem "json_pure"
+
+        group :development do
+          gem 'rails'
+        end
+
+        group :test do
+          gem 'json_pure'
+        end
+      end_gemfile
+
+    dsl = Bundler::FakeDsl.new(gemfile)
+    dsl.__groups[:development].should == ["rails"]
+    dsl.__groups[:test].should == ["json_pure"]
+  end
+end


### PR DESCRIPTION
The current spitball implementation currently breaks if you have group commands with multiple parameters. According to the bundler spec this should be valid http://bundler.io/v1.6/groups.html
