### PR TITLE
Cleanup spitball errors

### DIFF
--- a/bin/spitball-server
+++ b/bin/spitball-server
@@ -5,6 +5,7 @@ require 'optparse'
 require 'sinatra'
 require 'json'
 
+# TODO: Sinatra needs to be updated. Once we update let's add in auto-reload.
 # require "sinatra/reloader" if development?
 
 # cargo culting sinatra's option parser, since it has trouble

--- a/bin/spitball-server
+++ b/bin/spitball-server
@@ -5,6 +5,8 @@ require 'optparse'
 require 'sinatra'
 require 'json'
 
+# require "sinatra/reloader" if development?
+
 # cargo culting sinatra's option parser, since it has trouble
 # with rubygem stub files
 
@@ -19,9 +21,19 @@ OptionParser.new { |op|
 # always run
 set :run, true
 
+set :root, File.dirname(__FILE__)
+set :views, File.expand_path(File.join(settings.root, '..', 'lib', 'templates'))
+
 mime_type :gemfile, 'text/plain'
 mime_type :lock, 'text/plain'
 mime_type :tgz, 'application/x-compressed'
+
+get '/' do
+  @digests = Spitball::Repo.cached_digests
+  @env = `#{$:.inspect}\n#{Spitball.gem_cmd} env`
+  @protocol_version = Spitball::PROTOCOL_VERSION
+  erb :index
+end
 
 # return json array of cached SHAs
 get '/list' do
@@ -51,14 +63,27 @@ end
 # 202 Accepted if it does not. The body of the response is the URI for
 # the tarball.
 post '/create' do
-  request_version = request.env["HTTP_#{Spitball::PROTOCOL_HEADER.gsub(/-/, '_').upcase}"]
+
+  request_version = request.env["HTTP_#{Spitball::PROTOCOL_HEADER.gsub(/-/, '_').upcase}"] || params['protocol_version']
+  without = request.env["HTTP_#{Spitball::WITHOUT_HEADER.gsub(/-/, '_').upcase}"] || params['without']
+
   if request_version != Spitball::PROTOCOL_VERSION
     status 403
     "Received version #{request_version} but need version #{Spitball::PROTOCOL_VERSION}"
   else
-    without = request_version = request.env["HTTP_#{Spitball::WITHOUT_HEADER.gsub(/-/, '_').upcase}"]
+    without = request_version = without
     without &&= without.split(',')
-    ball = Spitball.new(params['gemfile'], params['gemfile_lock'], :without => without)
+
+    # begin
+      ball = Spitball.new(params['gemfile'], params['gemfile_lock'], :without => without)
+    # rescue Object => e
+    #   puts "error"
+    #   puts "error"
+    #   puts e.backtrace
+    #   status 500
+    #   return
+    # end
+
     url = "#{request.url.split("/create").first}/#{ball.digest}.tgz"
     response['Location'] = url
 

--- a/bin/spitball-server
+++ b/bin/spitball-server
@@ -90,15 +90,8 @@ post '/create_by_form' do
     halt 400, "gemfile_lock parameter was null. Please supply a valid Gemfile.lock"
   end
 
-  # begin
-    ball = Spitball.new(params[:gemfile][:tempfile].read, params[:gemfile_lock][:tempfile].read, :without => @without)
-  # rescue Object => e
-  #   puts "error"
-  #   puts "error"
-  #   puts e.backtrace
-  #   status 500
-  #   return
-  # end
+  # Since this is just a debugging form, I think it's ok to let any exception bubble up to the user
+  ball = Spitball.new(params[:gemfile][:tempfile].read, params[:gemfile_lock][:tempfile].read, :without => @without)
 
   spitball_url = "/#{ball.digest}.tgz"
 
@@ -116,15 +109,14 @@ end
 # the tarball.
 post '/create' do
 
-  # begin
+  # Spitball was previously returning the entire html stack trace on errors. This made it extremely difficult
+  # to debug on the client side. Gracefully handle errors here and return them nicely to the user.
+  begin
     ball = Spitball.new(params[:gemfile], params[:gemfile_lock], :without => @without)
-  # rescue Object => e
-  #   puts "error"
-  #   puts "error"
-  #   puts e.backtrace
-  #   status 500
-  #   return
-  # end
+  rescue Object => e
+    puts e.backtrace
+    halt 500, e.message
+  end
 
   response['Location'] = "#{request.url.split("/create").first}/#{ball.digest}.tgz"
 

--- a/bin/spitball-server
+++ b/bin/spitball-server
@@ -54,72 +54,118 @@ get '/:digest.:format' do |digest, format|
   send_file Spitball::Repo.bundle_path(digest, format), :type => format
 end
 
+# A common set of validation for the create spitball methods
+before '/create*' do
+  request_version = request.env["HTTP_#{Spitball::PROTOCOL_HEADER.gsub(/-/, '_').upcase}"] || params['protocol_version']
+
+  if request_version != Spitball::PROTOCOL_VERSION
+    halt 403, "Received version #{request_version} but need version #{Spitball::PROTOCOL_VERSION}"
+  end
+
+  if params[:gemfile].nil?
+    halt 400, "gemfile parameter was null. Please supply a valid Gemfile"
+  end
+
+  if params[:gemfile_lock].nil?
+    halt 400, "gemfile_lock parameter was null. Please supply a valid Gemfile.lock"
+  end
+
+  @without = request_version = request.env["HTTP_#{Spitball::WITHOUT_HEADER.gsub(/-/, '_').upcase}"] || params['without']
+  @without &&= @without.split(',')
+end
+
 class Streamer
   def initialize(io); @io = io end
   def each; while buf = @io.read(200); yield buf end end
 end
 
-# POST a gemfile. Returns 201 Created if the bundle already exists, or
+post '/create_by_form' do
+
+  # More specific validation checking for form upload data
+  if params[:gemfile][:tempfile].nil?
+    halt 400, "gemfile parameter was null. Please supply a valid Gemfile"
+  end
+
+  if params[:gemfile_lock][:tempfile].nil?
+    halt 400, "gemfile_lock parameter was null. Please supply a valid Gemfile.lock"
+  end
+
+  # begin
+    ball = Spitball.new(params[:gemfile][:tempfile].read, params[:gemfile_lock][:tempfile].read, :without => @without)
+  # rescue Object => e
+  #   puts "error"
+  #   puts "error"
+  #   puts e.backtrace
+  #   status 500
+  #   return
+  # end
+
+  spitball_url = "/#{ball.digest}.tgz"
+
+  if ball.cached?
+    redirect to(spitball_url)
+  else
+    status 202
+    create_spitball(ball)
+    body "Your spitball is being generated. Please check #{spitball_url} in a few minutes"
+  end
+end
+
+# POST a gemfile from a command line client. Returns 201 Created if the bundle already exists, or
 # 202 Accepted if it does not. The body of the response is the URI for
 # the tarball.
 post '/create' do
 
-  request_version = request.env["HTTP_#{Spitball::PROTOCOL_HEADER.gsub(/-/, '_').upcase}"] || params['protocol_version']
-  without = request.env["HTTP_#{Spitball::WITHOUT_HEADER.gsub(/-/, '_').upcase}"] || params['without']
+  # begin
+    ball = Spitball.new(params[:gemfile], params[:gemfile_lock], :without => @without)
+  # rescue Object => e
+  #   puts "error"
+  #   puts "error"
+  #   puts e.backtrace
+  #   status 500
+  #   return
+  # end
 
-  if request_version != Spitball::PROTOCOL_VERSION
-    status 403
-    "Received version #{request_version} but need version #{Spitball::PROTOCOL_VERSION}"
+  response['Location'] = "#{request.url.split("/create").first}/#{ball.digest}.tgz"
+
+  if ball.cached?
+    status 201
+    "Bundle tarball pre-cached.\n"
   else
-    without = request_version = without
-    without &&= without.split(',')
-
-    # begin
-      ball = Spitball.new(params['gemfile'], params['gemfile_lock'], :without => without)
-    # rescue Object => e
-    #   puts "error"
-    #   puts "error"
-    #   puts e.backtrace
-    #   status 500
-    #   return
-    # end
-
-    url = "#{request.url.split("/create").first}/#{ball.digest}.tgz"
-    response['Location'] = url
-
-    if ball.cached?
-      status 201
-      "Bundle tarball pre-cached.\n"
-    else
-      status 202
-
-      i,o = IO.pipe
-      o.sync = true
-
-      # fork twice. once so we can have a pid to detach from in order to clean up,
-      #             twice in order to properly redirect stdout for underlying shell commands.
-      pid = fork do
-        baller = open("|-")
-        if baller == nil # child
-          $stdout.sync = true
-          begin
-            ball.cache!
-          rescue Object => e
-            puts "#{e.class}: #{e}", e.backtrace.map{|l| "\t#{l}" }
-          end
-        else
-          while buf = baller.read(200)
-            $stdout.print buf
-            o.print buf
-          end
-        end
-        exit!
-      end
-
-      o.close
-      Process.detach(pid)
-
-      Streamer.new(i)
-    end
+    status 202
+    create_spitball(ball)
   end
+end
+
+private
+
+def create_spitball(spitball)
+
+  i,o = IO.pipe
+  o.sync = true
+
+  # fork twice. once so we can have a pid to detach from in order to clean up,
+  #             twice in order to properly redirect stdout for underlying shell commands.
+  pid = fork do
+    baller = open("|-")
+    if baller == nil # child
+      $stdout.sync = true
+      begin
+        spitball.cache!
+      rescue Object => e
+        puts "#{e.class}: #{e}", e.backtrace.map{|l| "\t#{l}" }
+      end
+    else
+      while buf = baller.read(200)
+        $stdout.print buf
+        o.print buf
+      end
+    end
+    exit!
+  end
+
+  o.close
+  Process.detach(pid)
+
+  Streamer.new(i)
 end

--- a/lib/spitball/version.rb
+++ b/lib/spitball/version.rb
@@ -1,3 +1,3 @@
 class Spitball
-  VERSION = '0.7.3' unless const_defined?(:VERSION)
+  VERSION = '0.7.4' unless const_defined?(:VERSION)
 end

--- a/lib/spitball/version.rb
+++ b/lib/spitball/version.rb
@@ -1,3 +1,3 @@
 class Spitball
-  VERSION = '0.7.4' unless const_defined?(:VERSION)
+  VERSION = '0.8.0' unless const_defined?(:VERSION)
 end

--- a/lib/templates/index.erb
+++ b/lib/templates/index.erb
@@ -1,0 +1,23 @@
+<h2>Spitball!</h2>
+
+<div style="float: left; width: 50%;">
+  <h3>Env</h3>
+  <div><pre><%= @env %></pre></div>
+  <h3>Cached Digests</h3>
+  <% for digest in @digests %>
+    <div><%= digest %> <a href="/<%= digest %>.tgz">tgz</a></div>
+  <% end %>
+</div>
+
+<div style="float: left;">
+  <h3>Upload</h3>
+  <form method="post" action="create">
+    <div>Gemfile: <input type="file" name="gemfile"/></div>
+    <div>Gemfile.lock: <input type="file" name="gemfile_lock"/></div>
+    <div>Without groups: <input type="text" name="without"/></div>
+    <input type="hidden" name="protocol_version" value="<%= @protocol_version %>"/>
+    <input type="submit" value="submit"/>
+  </form>
+</div>
+
+<div style="clear: both;"></div>

--- a/lib/templates/index.erb
+++ b/lib/templates/index.erb
@@ -3,15 +3,19 @@
 <div style="float: left; width: 50%;">
   <h3>Env</h3>
   <div><pre><%= @env %></pre></div>
-  <h3>Cached Digests</h3>
+  <h3><%= @digests.length %> Cached Digests</h3>
+  <div style="min-height: 400px; overflow: auto;">
+  <ul>
   <% for digest in @digests %>
-    <div><%= digest %> <a href="/<%= digest %>.tgz">tgz</a></div>
+    <li><%= digest %> <a href="/<%= digest %>.tgz">tgz</a></li>
   <% end %>
+  </ul>
+</div>
 </div>
 
 <div style="float: left;">
   <h3>Upload</h3>
-  <form method="post" action="create">
+  <form method="post" action="/create_by_form" enctype='multipart/form-data'>
     <div>Gemfile: <input type="file" name="gemfile"/></div>
     <div>Gemfile.lock: <input type="file" name="gemfile_lock"/></div>
     <div>Without groups: <input type="text" name="without"/></div>

--- a/spec/spitball_spec.rb
+++ b/spec/spitball_spec.rb
@@ -2,8 +2,6 @@ require './spec/spec_helper'
 
 describe Spitball do
   before do
-    use_success_bundler
-
     @gemfile = <<-end_gemfile
         source :rubygems
         gem "json_pure"

--- a/spec/spitball_spec.rb
+++ b/spec/spitball_spec.rb
@@ -352,7 +352,7 @@ describe Spitball do
         end_gemfile
 
       lockfile = <<-end_lockfile.strip.gsub(/\n[ ]{8}/m, "\n")
-        GGGGEM
+        SYNTAXERROR
           remote: http://rubygems.org/
           specs:
             activemodel (3.0.1)

--- a/spec/spitball_spec.rb
+++ b/spec/spitball_spec.rb
@@ -300,8 +300,87 @@ describe Spitball do
 
     describe "create_bundle failure" do
       it "should raise on create_bundle" do
+        use_success_bundler
         proc { Spitball.new(@gemfile, @lockfile) }.should raise_error
       end
+    end
+  end
+
+  context "error handling" do
+
+    it "should throw an exception on an invalid Gemfile" do
+
+      gemfile = <<-end_gemfile
+          source :rubygems
+          gem "activerecord"
+          raise 'foo'
+        end_gemfile
+
+      lockfile = <<-end_lockfile.strip.gsub(/\n[ ]{8}/m, "\n")
+        GEM
+          remote: http://rubygems.org/
+          specs:
+            activemodel (3.0.1)
+              activesupport (= 3.0.1)
+              builder (~> 2.1.2)
+              i18n (~> 0.4.1)
+            activerecord (3.0.1)
+              activemodel (= 3.0.1)
+              activesupport (= 3.0.1)
+              arel (~> 1.0.0)
+              tzinfo (~> 0.3.23)
+            activesupport (3.0.1)
+            arel (1.0.1)
+              activesupport (~> 3.0.0)
+            builder (2.1.2)
+            i18n (0.4.2)
+            tzinfo (0.3.23)
+
+        PLATFORMS
+          ruby
+
+        DEPENDENCIES
+          activerecord
+      end_lockfile
+
+      proc { Spitball.new(gemfile, lockfile) }.should raise_error(Spitball::GemfileParsingError, 'There was an error parsing your Gemfile. Please ensure the file is valid and try again')
+    end
+
+    it "should throw an exception on an invalid Gemfile.lock" do
+
+      gemfile = <<-end_gemfile
+          source :rubygems
+          gem "activerecord"
+        end_gemfile
+
+      lockfile = <<-end_lockfile.strip.gsub(/\n[ ]{8}/m, "\n")
+        GGGGEM
+          remote: http://rubygems.org/
+          specs:
+            activemodel (3.0.1)
+              activesupport (= 3.0.1)
+              builder (~> 2.1.2)
+              i18n (~> 0.4.1)
+            activerecord (3.0.1)
+              activemodel (= 3.0.1)
+              activesupport (= 3.0.1)
+              arel (~> 1.0.0)
+              tzinfo (~> 0.3.23)
+            activesupport (3.0.1)
+            arel (1.0.1)
+              activesupport (~> 3.0.0)
+            builder (2.1.2)
+            i18n (0.4.2)
+            tzinfo (0.3.23)
+
+        PLATFORMS
+          ruby
+
+        DEPENDENCIES
+          activerecord
+      end_lockfile
+
+      proc { Spitball.new(gemfile, lockfile) }.should raise_error(Spitball::GemfileParsingError, 'There was an error parsing your gemfile.lock. Please ensure the file is valid and try again')
     end
   end
 end


### PR DESCRIPTION
The most annoying thing with spitball are the errors that are returned when there is a problem parsing the gemfile or gemfile.lock. The server ends up returning a ton of HTML which makes it almost impossible to debug. I've tried to make this better by raise specific errors when parsing gemfiles, catching them in the server code, and returning them in a nicer way to the client.

In an effort to make debugging easier I've also added a html dashboard on the / route that lets you upload from the web instead of the client.
