### PR TITLE
Option to provide a bundle-config file that passes its parameters to spitball

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ rvm:
   - 1.8.7
   - 1.9.3
   - 2.0.0
+  - 2.1.6
+  - 2.2.1
 before_install:
   - gem update --system 2.1.11
   - gem --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.6
-  - 2.2.1
 before_install:
   - gem update --system 2.1.11
   - gem --version

--- a/bin/spitball
+++ b/bin/spitball
@@ -30,6 +30,10 @@ opts = OptionParser.new do |opts|
     args[:without] = without
   end
 
+  opts.on('--bundle-config CONFIG_FILE', 'Pass a bundle-config styled configuration file with build instructions') do |bundle_config|
+    args[:bundle_config] = bundle_config
+  end
+
   opts.on('-g', '--generate-only', "Only generate, don't download") do
     args[:generate] = true
   end
@@ -52,9 +56,11 @@ end
 
 gemfile = File.read(args[:gemfile])
 gemfile_lock = File.read("#{args[:gemfile]}.lock")
+bundle_config = File.read(args[:bundle_config]) if args[:bundle_config]
 
 ball = args[:host] ?
-  Spitball::Remote.new(gemfile, gemfile_lock, :host => args[:host], :port => (args[:port] || 8080).to_i, :without => args[:without]) :
-  Spitball.new(gemfile, gemfile_lock, :without => args[:without])
+  Spitball::Remote.new(gemfile, gemfile_lock, :host => args[:host], :port => (args[:port] || 8080).to_i,
+    :without => args[:without], :bundle_config => bundle_config) :
+  Spitball.new(gemfile, gemfile_lock, :without => args[:without], :bundle_config => bundle_config)
 
 args[:generate] ? ball.cache! : ball.copy_to(args[:destination])

--- a/bin/spitball-server
+++ b/bin/spitball-server
@@ -61,7 +61,7 @@ post '/create' do
   else
     without = request_version = request.env["HTTP_#{Spitball::WITHOUT_HEADER.gsub(/-/, '_').upcase}"]
     without &&= without.split(',')
-    ball = Spitball.new(params['gemfile'], params['gemfile_lock'], :without => without)
+    ball = Spitball.new(params['gemfile'], params['gemfile_lock'], :without => without, :bundle_config => params['bundle_config'])
     url = "#{request.url.split("/create").first}/#{ball.digest}.tgz"
     response['Location'] = url
 

--- a/lib/spitball/version.rb
+++ b/lib/spitball/version.rb
@@ -1,3 +1,3 @@
 class Spitball
-  VERSION = '0.7.5' unless const_defined?(:VERSION)
+  VERSION = '0.8.0' unless const_defined?(:VERSION)
 end

--- a/spec/spitball_spec.rb
+++ b/spec/spitball_spec.rb
@@ -80,6 +80,16 @@ describe Spitball do
     end
   end
 
+  describe "generate_build_args" do
+    it "returns an empty string for nil" do
+      @spitball.send(:generate_build_args, nil).should == ''
+    end
+
+    it "returns arguments prepended with double dashes for a string" do
+      @spitball.send(:generate_build_args, '--build-args=joesmith').should == '-- --build-args=joesmith'
+    end
+  end
+
   describe "create_bundle" do
     it "generates a bundle at the bundle_path" do
       mock(@spitball).install_gem(anything).times(any_times)
@@ -143,7 +153,7 @@ describe Spitball do
       @spitball.send(:sources_opt, parsed_lockfile.sources).should == "--source http://rubygems.org/"
     end
 
-    it "does not add --clear sources for rubygems >= 1.4.0" do
+    it "adds --clear sources for rubygems >= 1.4.0" do
       @spitball = Spitball.new(@gemfile, @lockfile)
       parsed_lockfile =  @spitball.instance_variable_get("@parsed_lockfile")
       Gem::VERSION = "1.4.0"


### PR DESCRIPTION
Adds --bundle-config which accepts a file location containing a bundle-config file. This file is passed to Bundler::Settings and used when building gems.

Example:

A bundle-config file containing:

    ---
    BUNDLE_BUILD_MYSQL: --with-lib-dir=/mycustomlibdir

Would execute:

    gem install mysql -- --with-lib-dir=/mycustomlibdir

This allows users to tell spitball how to compile a gem if the user does not have access to modify the build environment on the spitball remote host.