### PR TITLE
Handle invalid semantic version from rubygems

### DIFF
--- a/lib/spitball.rb
+++ b/lib/spitball.rb
@@ -169,7 +169,7 @@ class Spitball
         sort.
         map{|s| %w{gemcutter rubygems rubyforge}.include?(s) ? "http://rubygems.org" : s}).
         map{|s| "--source #{s}"}.
-        map{|s| "#{"--clear-sources " if SemVer.parse(Gem::VERSION) >= SemVer.parse('1.4.0') }#{s}"}.
+        map{|s| "#{"--clear-sources " if SemVer.parse(Gem::VERSION.split('.')[0..2].join('.')) >= SemVer.parse('1.4.0') }#{s}"}.
         join(' ')
   end
 

--- a/lib/spitball/version.rb
+++ b/lib/spitball/version.rb
@@ -1,3 +1,3 @@
 class Spitball
-  VERSION = '0.8.1' unless const_defined?(:VERSION)
+  VERSION = '0.8.2' unless const_defined?(:VERSION)
 end


### PR DESCRIPTION
Works ok for me with ruby 1.9.3p551 (gem version 1.8.23.2)