### PR TITLE
Use https instead of http in urls

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ project:
 
 4. Push your topic branch up to your fork:
 
-5. [Open a Pull Request](http://help.github.com/send-pull-requests/) with a
+5. [Open a Pull Request](https://help.github.com/send-pull-requests/) with a
    clear title and description.
 
 ## License

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## spitball [![Build Status](https://secure.travis-ci.org/twitter/spitball.png?branch=master)](http://travis-ci.org/twitter/spitball) [![Code Climate](https://codeclimate.com/github/twitter/spitball.png)](https://codeclimate.com/github/twitter/spitball)
+## spitball [![Build Status](https://secure.travis-ci.org/twitter/spitball.png?branch=master)](https://travis-ci.org/twitter/spitball) [![Code Climate](https://codeclimate.com/github/twitter/spitball.png)](https://codeclimate.com/github/twitter/spitball)
 
 A very simple gem package generation tool built on `bundler`. Pass it a
 gem file, it spits out a tarball of the generated gem

--- a/lib/spitball.rb
+++ b/lib/spitball.rb
@@ -160,7 +160,7 @@ class Spitball
         map{|s| s.remotes}.flatten.
         map{|s| s.to_s}.
         sort.
-        map{|s| %w{gemcutter rubygems rubyforge}.include?(s) ? "http://rubygems.org" : s}).
+        map{|s| %w{gemcutter rubygems rubyforge}.include?(s) ? "https://rubygems.org" : s}).
         map{|s| "--source #{s}"}.
         map{|s| "#{"--clear-sources " if SemVer.parse(Gem::VERSION.split('.')[0..2].join('.')) >= SemVer.parse('1.4.0') }#{s}"}.
         join(' ')

--- a/lib/spitball/remote.rb
+++ b/lib/spitball/remote.rb
@@ -35,7 +35,7 @@ class Spitball::Remote
   def cache!(sync = true) # ignore sync
     return if cached?
 
-    url = URI.parse("http://#{@host}:#{@port}/create")
+    url = URI.parse("https://#{@host}:#{@port}/create")
     req = Net::HTTP::Post.new(url.path)
     data = {'gemfile' => @gemfile, 'gemfile_lock' => @gemfile_lock}
     data['bundle_config'] = @bundle_config if @bundle_config

--- a/spec/spitball_spec.rb
+++ b/spec/spitball_spec.rb
@@ -11,7 +11,7 @@ describe Spitball do
 
     @lockfile = <<-end_lockfile.strip.gsub(/\n[ ]{6}/m, "\n")
       GEM
-        remote: http://rubygems.org/
+        remote: https://rubygems.org/
         specs:
           json_pure (1.4.6)
 
@@ -116,7 +116,7 @@ describe Spitball do
 
       @lockfile = <<-end_lockfile.strip.gsub(/\n[ ]{8}/m, "\n")
         GEM
-          remote: http://rubygems.org/
+          remote: https://rubygems.org/
           specs:
             activemodel (3.0.1)
               activesupport (= 3.0.1)
@@ -160,14 +160,14 @@ describe Spitball do
       @spitball = Spitball.new(@gemfile, @lockfile)
       parsed_lockfile =  @spitball.instance_variable_get("@parsed_lockfile")
       stub_const("Gem::VERSION", "1.3.10")
-      expect(@spitball.send(:sources_opt, parsed_lockfile.sources)).to eq("--source http://rubygems.org/")
+      expect(@spitball.send(:sources_opt, parsed_lockfile.sources)).to eq("--source https://rubygems.org/")
     end
 
     it "adds --clear sources for rubygems >= 1.4.0" do
       @spitball = Spitball.new(@gemfile, @lockfile)
       parsed_lockfile =  @spitball.instance_variable_get("@parsed_lockfile")
       stub_const("Gem::VERSION", "1.4.0")
-      expect(@spitball.send(:sources_opt, parsed_lockfile.sources)).to eq("--clear-sources --source http://rubygems.org/")
+      expect(@spitball.send(:sources_opt, parsed_lockfile.sources)).to eq("--clear-sources --source https://rubygems.org/")
     end
   end
 end
@@ -307,7 +307,7 @@ describe Spitball do
 
       @lockfile = <<-end_lockfile.strip.gsub(/\n[ ]{6}/m, "\n")
         GEM
-          remote: http://rubygems.org/
+          remote: https://rubygems.org/
           specs:
             json_pure (1.4.6)
 

--- a/spitball.gemspec
+++ b/spitball.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Matt Freels", "Brandon Mitchell", "Joshua Hull"]
   s.email       = "freels@twitter.com"
-  s.homepage    = "http://github.com/twitter/spitball"
+  s.homepage    = "https://github.com/twitter/spitball"
   s.summary     = %q{Use bundler to generate gem tarball packages}
   s.description = %q{Use bundler to generate gem tarball packages.}
 


### PR DESCRIPTION
This PR changes every instance of an http url to its https version for security reasons.