### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/spitball-server.gemspec
+++ b/spitball-server.gemspec
@@ -11,8 +11,6 @@ Gem::Specification.new do |s|
   s.summary     = %q{Use bundler to generate gem tarball packages -- server!}
   s.description = %q{Use bundler to generate gem tarball packages - server!}
 
-  s.rubyforge_project = "spitball-server"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = ['spitball-server', 'spitball-cache-cleanup']

--- a/spitball.gemspec
+++ b/spitball.gemspec
@@ -11,8 +11,6 @@ Gem::Specification.new do |s|
   s.summary     = %q{Use bundler to generate gem tarball packages}
   s.description = %q{Use bundler to generate gem tarball packages.}
 
-  s.rubyforge_project = "spitball"
-
   s.add_dependency 'sem_ver'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'diff-lcs'


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.